### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: go
 
 notifications:
   slack:
+    on_success: change
+    on_failure: always
     rooms:
       - whythehellnot:RlQRu5Twg2ZsabMC6K4SL6hu#travis
+      - whythehellnot:RlQRu5Twg2ZsabMC6K4SL6hu#commits


### PR DESCRIPTION
Update travis to only post to slack when a build fails (or if the build was failing then the first time it succeeds). This means that the #travis channel doesn't have to be muted and we can instead use the #commits channel to alert anyone who pushed a commit that failed.